### PR TITLE
Refresh Postgres database connection when lost

### DIFF
--- a/server/api/[table]/alerts.ts
+++ b/server/api/[table]/alerts.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, sendError, H3Event } from "h3";
-import { configDb, db } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import { fetchConfig, fetchData } from "../../database/dbOperations";
 import {
   prepareAlertData,
@@ -31,6 +31,9 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const configDb = await getDatabaseConnection(true);
+    const db = await getDatabaseConnection(false);
+
     const viewsConfig = await fetchConfig(configDb, isSqlite);
     const { mainData, metadata } = (await fetchData(db, table, isSqlite)) as {
       mainData: DataEntry[];

--- a/server/api/[table]/data.ts
+++ b/server/api/[table]/data.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, sendError, H3Event } from "h3";
-import { db } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import { fetchData } from "../../database/dbOperations";
 
 export default defineEventHandler(async (event: H3Event) => {
@@ -13,6 +13,8 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const db = await getDatabaseConnection(false);
+
     const { mainData, columnsData } = await fetchData(db, table, isSqlite);
     return { data: mainData, columns: columnsData };
   } catch (error) {

--- a/server/api/[table]/gallery.ts
+++ b/server/api/[table]/gallery.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, sendError, H3Event } from "h3";
-import { configDb, db } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import { fetchConfig, fetchData } from "../../database/dbOperations";
 import { transformSurveyData } from "../../dataProcessing/transformData";
 import {
@@ -26,6 +26,9 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const configDb = await getDatabaseConnection(true);
+    const db = await getDatabaseConnection(false);
+
     const viewsConfig = await fetchConfig(configDb, isSqlite);
     const { mainData, columnsData } = await fetchData(db, table, isSqlite);
 

--- a/server/api/[table]/map.ts
+++ b/server/api/[table]/map.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, sendError, H3Event } from "h3";
-import { configDb, db } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import { fetchConfig, fetchData } from "../../database/dbOperations";
 import {
   prepareMapData,
@@ -29,6 +29,9 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const configDb = await getDatabaseConnection(true);
+    const db = await getDatabaseConnection(false);
+
     const viewsConfig = await fetchConfig(configDb, isSqlite);
     const { mainData, columnsData } = await fetchData(db, table, isSqlite);
 

--- a/server/api/config/delete_table/[table].post.ts
+++ b/server/api/config/delete_table/[table].post.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, sendError, H3Event } from "h3";
-import { configDb } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import { removeTableFromConfig } from "../../../database/dbOperations";
 
 export default defineEventHandler(async (event: H3Event) => {
@@ -13,6 +13,8 @@ export default defineEventHandler(async (event: H3Event) => {
   const table = event.context?.params?.table as string;
 
   try {
+    const configDb = await getDatabaseConnection(true);
+
     await removeTableFromConfig(configDb, table, isSqlite);
     return { message: "Table removed from views configuration." };
   } catch (error) {

--- a/server/api/config/index.get.ts
+++ b/server/api/config/index.get.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, sendError, H3Event } from "h3";
-import { configDb, db } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import { fetchConfig } from "@/server/database/dbOperations";
 import { getFilteredTableNames } from "./utils";
 
@@ -12,6 +12,9 @@ export default defineEventHandler(async (event: H3Event) => {
   };
 
   try {
+    const configDb = await getDatabaseConnection(true);
+    const db = await getDatabaseConnection(false);
+
     const viewsConfig = await fetchConfig(configDb, isSqlite);
     const tableNames = await getFilteredTableNames(db, isSqlite);
 

--- a/server/api/config/new_table/[table].post.ts
+++ b/server/api/config/new_table/[table].post.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, sendError, H3Event } from "h3";
-import { configDb } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import { addNewTableToConfig } from "../../../database/dbOperations";
 
 export default defineEventHandler(async (event: H3Event) => {
@@ -12,6 +12,8 @@ export default defineEventHandler(async (event: H3Event) => {
 
   const table = event.context?.params?.table as string;
   try {
+    const configDb = await getDatabaseConnection(true);
+
     await addNewTableToConfig(configDb, table, isSqlite);
     return { message: "New table added successfully" };
   } catch (error) {

--- a/server/api/config/update_config/[table].post.ts
+++ b/server/api/config/update_config/[table].post.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, sendError, readBody, H3Event } from "h3";
-import { configDb } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import { updateConfig } from "../../../database/dbOperations";
 
 export default defineEventHandler(async (event: H3Event) => {
@@ -14,6 +14,8 @@ export default defineEventHandler(async (event: H3Event) => {
   const config = await readBody(event);
 
   try {
+    const configDb = await getDatabaseConnection(true);
+
     await updateConfig(configDb, table, config, isSqlite);
     return { message: "Configuration updated successfully" };
   } catch (error) {

--- a/server/database/dbConfig.ts
+++ b/server/database/dbConfig.ts
@@ -1,0 +1,36 @@
+export const getConfig = () => {
+  const {
+    configDatabase,
+    database,
+    dbHost,
+    dbUser,
+    dbPassword,
+    dbPort,
+    dbSsl,
+    isSQLite,
+    sqliteDbPath,
+    // eslint-disable-next-line no-undef
+  } = useRuntimeConfig() as unknown as {
+    configDatabase: string;
+    database: string;
+    dbHost: string;
+    dbUser: string;
+    dbPassword: string;
+    dbPort: string;
+    dbSsl: boolean;
+    isSQLite: boolean;
+    sqliteDbPath: string;
+  };
+
+  return {
+    configDatabase,
+    database,
+    dbHost,
+    dbUser,
+    dbPassword,
+    dbPort,
+    dbSsl,
+    isSQLite,
+    sqliteDbPath,
+  };
+};

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -11,11 +11,11 @@ import {
 const checkTableExists = (
   db: DatabaseConnection,
   table: string | undefined,
-  isSqlite: boolean | undefined,
+  isSQLite: boolean | undefined,
 ): Promise<boolean> => {
   return new Promise((resolve, reject) => {
     let query: string;
-    if (isSqlite) {
+    if (isSQLite) {
       const sqliteDb = db as SqliteDatabase;
       query = `SELECT name FROM sqlite_master WHERE type='table' AND name='${table}'`;
       sqliteDb.all(query, (err: Error, rows: unknown[]) => {
@@ -40,10 +40,10 @@ const checkTableExists = (
 const fetchDataFromTable = async (
   db: DatabaseConnection,
   table: string | undefined,
-  isSqlite: boolean | undefined,
+  isSQLite: boolean | undefined,
 ): Promise<unknown[]> => {
   let query: string;
-  if (isSqlite) {
+  if (isSQLite) {
     const sqliteDb = db as SqliteDatabase;
     query = `SELECT * FROM ${table}`;
     return new Promise((resolve, reject) => {
@@ -73,7 +73,7 @@ const fetchDataFromTable = async (
 export const fetchData = async (
   db: DatabaseConnection,
   table: string | undefined,
-  isSqlite: boolean | undefined,
+  isSQLite: boolean | undefined,
 ): Promise<{
   mainData: DataEntry[];
   columnsData: ColumnEntry[] | null;
@@ -81,23 +81,23 @@ export const fetchData = async (
 }> => {
   console.log("Fetching data from", table, "...");
   // Fetch data
-  const mainDataExists = await checkTableExists(db, table, isSqlite);
+  const mainDataExists = await checkTableExists(db, table, isSQLite);
   let mainData: DataEntry[] = [];
   if (mainDataExists) {
-    mainData = (await fetchDataFromTable(db, table, isSqlite)) as DataEntry[];
+    mainData = (await fetchDataFromTable(db, table, isSQLite)) as DataEntry[];
   } else {
     throw new Error("Main table does not exist");
   }
 
   // Fetch mapping columns
   const columnsTable = `${table}__columns`;
-  const columnsTableExists = await checkTableExists(db, columnsTable, isSqlite);
+  const columnsTableExists = await checkTableExists(db, columnsTable, isSQLite);
   let columnsData = null;
   if (columnsTableExists) {
     columnsData = (await fetchDataFromTable(
       db,
       columnsTable,
-      isSqlite,
+      isSQLite,
     )) as ColumnEntry[];
   }
 
@@ -106,11 +106,11 @@ export const fetchData = async (
   const metadataTableExists = await checkTableExists(
     db,
     metadataTable,
-    isSqlite,
+    isSQLite,
   );
   let metadata = null;
   if (metadataTableExists) {
-    metadata = await fetchDataFromTable(db, metadataTable, isSqlite);
+    metadata = await fetchDataFromTable(db, metadataTable, isSQLite);
   }
 
   console.log("Successfully fetched data from", table, "!");
@@ -120,14 +120,14 @@ export const fetchData = async (
 
 export const fetchTableNames = async (
   db: DatabaseConnection,
-  isSqlite: boolean | undefined,
+  isSQLite: boolean | undefined,
 ): Promise<string[]> => {
-  const query = isSqlite
+  const query = isSQLite
     ? `SELECT name FROM sqlite_master WHERE type='table'`
     : `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`;
 
   return new Promise((resolve, reject) => {
-    if (isSqlite) {
+    if (isSQLite) {
       const sqliteDb = db as SqliteDatabase;
       sqliteDb.all<{ name: string }>(
         query,

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,73 +1,13 @@
-import { setupDatabaseConnection } from "./database/dbConnection";
-import { type DatabaseConnection } from "./types";
-
-let configDb: DatabaseConnection;
-let db: DatabaseConnection;
-
-const {
-  configDatabase,
-  database,
-  dbHost,
-  dbUser,
-  dbPassword,
-  dbPort,
-  dbSsl,
-  isSqlite,
-  sqliteDbPath,
-  // eslint-disable-next-line no-undef
-} = useRuntimeConfig() as unknown as {
-  configDatabase: string;
-  database: string;
-  dbHost: string;
-  dbUser: string;
-  dbPassword: string;
-  dbPort: string;
-  dbSsl: boolean;
-  isSqlite: boolean;
-  sqliteDbPath: string;
-};
+import { refreshDatabaseConnection } from "./database/dbConnection";
 
 export default async () => {
   try {
-    configDb = await setupDatabaseConnection(
-      /* isConfigDb */ true,
-      isSqlite,
-      sqliteDbPath,
-      configDatabase,
-      database,
-      dbHost,
-      dbUser,
-      dbPassword,
-      dbPort,
-      dbSsl,
-    );
+    await refreshDatabaseConnection(false);
   } catch (error) {
     if (error instanceof Error) {
-      throw new Error(`Failed to connect to ${configDatabase}:`, error);
-    } else {
-      console.error("Unknown error connecting to database:", error);
-    }
-  }
-  try {
-    db = await setupDatabaseConnection(
-      /* isConfigDb */ false,
-      isSqlite,
-      sqliteDbPath,
-      database,
-      database,
-      dbHost,
-      dbUser,
-      dbPassword,
-      dbPort,
-      dbSsl,
-    );
-  } catch (error) {
-    if (error instanceof Error) {
-      throw new Error(`Failed to connect to ${database}:`, error);
+      throw new Error(`Failed to connect to database: ${error.message}`);
     } else {
       console.error("Unknown error connecting to database:", error);
     }
   }
 };
-
-export { configDb, db };


### PR DESCRIPTION
## Goal

Closes #81.

The goal here is to refresh a Postgres database connection when discovered to have been lost. 

## Screenshots

Not a screenshot but a Nuxt server console log of what happens when a page is requested after a db is reset. The page will load as expected.

```
Fetching data from mapeo_data ...
Successfully fetched data from mapeo_data !

 ERROR  [nitro] [uncaughtException] terminating connection due to administrator command

 ERROR  [nitro] [uncaughtException] terminating connection due to administrator command

 ERROR  [nitro] [uncaughtException] Connection terminated unexpectedly

 ERROR  [nitro] [uncaughtException] Connection terminated unexpectedly

 WARN  Error encountered when checking PostgreSQL connection: Client has encountered a connection error and is not queryable

Reconnecting to PostgreSQL...
Setting up database connection to guardianconnector...
Connected to the PostgreSQL database: "guardianconnector"

 WARN  Error encountered when checking PostgreSQL connection: Client has encountered a connection error and is not queryable

Reconnecting to PostgreSQL...
Setting up database connection to warehouse...
Connected to the PostgreSQL database: "warehouse"
Fetching data from mapeo_data ...
Successfully fetched data from mapeo_data !
```

## What I changed

* Added `refreshDatabaseConnection`: Initializes the database connection on startup and re-establishes it if a disconnection is detected.
* Created `getDatabaseConnection`: Centralizes access to db and configdb connections. This function mirrors the Nitro module’s prior setup but revalidates the connection each time by:
  * Calling `ensurePostgresConnection`, which:
    * Executes a simple query to confirm connectivity.
    * Invokes `refreshDatabaseConnection` if the query fails.
  * Refactored database configuration code into a standalone `getConfig` function to improve readability.\
* Renaming of a few vars across functions for consistency. 