### PR TITLE
Implement custom multi tag for Vue 3 Select component

### DIFF
--- a/components/shared/DataFilter.vue
+++ b/components/shared/DataFilter.vue
@@ -62,19 +62,23 @@ function emitFilter() {
       :key="uniqueValues"
     >
       <!-- This is what shows in the listbox when selected -->
-      <!-- Pending support for tags https://github.com/TotomInc/vue3-select-component/pull/129 -->
-      <template #tag="{ option }">
-        <span
-          class="colored-dot"
-          v-if="showColoredDot"
-          :style="{ backgroundColor: option.color }"
-        ></span>
-        {{ option.label }}
+      <template #tag="{ option, removeOption }">
+        <div class="option-box">
+          <span
+            class="colored-dot"
+            v-if="showColoredDot"
+            :style="{ backgroundColor: option.color }"
+          ></span>
+          <span class="selected-label">
+            {{ option.label }}
+            <button type="button" @click="removeOption">&times;</button>
+          </span>
+        </div>
       </template>
       <!-- These are the options in the dropdown -->
       <template #option="{ option }">
         <span
-          class="colored-dot"
+          class="colored-dot dot-dropdown"
           v-if="showColoredDot"
           :style="{ backgroundColor: option.color }"
         ></span>
@@ -111,13 +115,41 @@ function emitFilter() {
 
     --vs-selected-bg: #f9f9f9;
 
+    .option-box {
+      --vs-multi-value-gap: 4px;
+
+      display: flex;
+      align-items: center;
+      gap: var(--vs-multi-value-gap);
+      border-radius: 4px;
+      border: 1px solid rgba(0, 0, 0, 0.1);
+      padding: var(--vs-multi-value-padding);
+      margin: var(--vs-multi-value-margin);
+      color: var(--vs-multi-value-text-color);
+      line-height: var(--vs-multi-value-line-height);
+      background: var(--vs-multi-value-bg);
+    }
+
+    .option-box button {
+      font-size: 1.25rem;
+      background: none;
+      transform: translateY(1px); /* Move text 3px lower */
+    }
+
     .colored-dot {
       width: 12px;
       height: 12px;
       border-radius: 50%;
       display: inline-block;
+      margin: 0 5px;
+    }
+
+    .dot-dropdown {
+      margin: 5px 5px 0 0;
+    }
+
+    .selected-label {
       margin-right: 5px;
-      margin-top: 5px;
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "vue-chartjs": "^5.3.1",
         "vue-datepicker-next": "^1.0.3",
         "vue-router": "latest",
-        "vue3-select-component": "^0.6.1"
+        "vue3-select-component": "^0.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
@@ -17719,9 +17719,9 @@
       }
     },
     "node_modules/vue3-select-component": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/vue3-select-component/-/vue3-select-component-0.6.1.tgz",
-      "integrity": "sha512-5sFZXaq9p23ErcXmc3KcuJMkxUzNbmwf+xqEms5tX/n5310ZXYB1t0q7Q0vvcihlyHN8c+YciwnI2qgbbjwrpQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/vue3-select-component/-/vue3-select-component-0.7.0.tgz",
+      "integrity": "sha512-sJwUIICUWey5934yC8YVlOD+SUrhtHUocMqOP0eGwUOZPCX4n0hufdlxVMAYCk+h5rDJJ7orqOKRHqx5T5+q4w==",
       "peerDependencies": {
         "vue": "^3.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "vue-chartjs": "^5.3.1",
     "vue-datepicker-next": "^1.0.3",
     "vue-router": "latest",
-    "vue3-select-component": "^0.6.1"
+    "vue3-select-component": "^0.7.0"
   },
   "lint-staged": {
     "./**/*.{js,jsx,ts,tsx,json,css,vue}": [


### PR DESCRIPTION
## Goal

Now that [`vue3-select-component` allows a custom option slot for #value when `isMulti` is set](https://github.com/TotomInc/vue3-select-component/issues/128), this PR re-adds the selected colored dots shown on the map into the listbox for our `DataFilter` component, as we had them in the Vue 2 select component.

## Screenshots

![image](https://github.com/user-attachments/assets/ac15c6dc-4fc4-43bb-94f8-c8e291f40cae)

## What I changed

* Bumped `vue3-select-component` to 0.7.0.
* Adapted HTML and CSS for the listbox template to show colored dots and style the option boxes similar to what we had before.