### PR TITLE
Add `mapbox-gl-ruler-control` to AlertsDashboard component

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -10,6 +10,7 @@ import bbox from "@turf/bbox";
 import { lineString } from "@turf/helpers";
 import length from "@turf/length";
 import along from "@turf/along";
+import rulerControl from "mapbox-gl-ruler-control";
 
 import {
   changeMapStyle,
@@ -45,6 +46,7 @@ const props = defineProps({
 
 const calculateHectares = ref(false);
 const dateOptions = ref([]);
+const hasRulerControl = ref(false);
 const map = ref(null);
 const showBasemapSelector = ref(false);
 const showIntroPanel = ref(true);
@@ -92,6 +94,11 @@ onMounted(() => {
     // Fullscreen Control
     const fullscreenControl = new mapboxgl.FullscreenControl();
     map.value.addControl(fullscreenControl, "top-right");
+
+    // Ruler control
+    const ruler = new rulerControl();
+    map.value.addControl(ruler, "top-right");
+    hasRulerControl.value = true;
 
     showBasemapSelector.value = true;
 
@@ -996,6 +1003,7 @@ onBeforeUnmount(() => {
     />
     <BasemapSelector
       v-if="showBasemapSelector"
+      :has-ruler-control="hasRulerControl"
       :mapbox-style="mapboxStyle"
       :planet-api-key="planetApiKey"
       @basemapSelected="handleBasemapChange"
@@ -1018,6 +1026,16 @@ body {
 
 .mapboxgl-popup-content {
   word-wrap: break-word;
+}
+
+:deep(.mapboxgl-ctrl-ruler) {
+  img {
+    margin-left: 3px;
+  }
+
+  .active {
+    background-color: #fff44f;
+  }
 }
 
 .popup-media {

--- a/components/shared/BasemapSelector.vue
+++ b/components/shared/BasemapSelector.vue
@@ -5,11 +5,14 @@ import Datepicker from "vue-datepicker-next";
 import "vue-datepicker-next/index.css";
 
 const props = defineProps({
+  hasRulerControl: Boolean,
   mapboxStyle: String,
   planetApiKey: String,
 });
 
 const emit = defineEmits(["basemapSelected"]);
+
+const topPosition = computed(() => (props.hasRulerControl ? "187px" : "147px"));
 
 const showBasemapWindow = ref(false);
 const selectedBasemap = ref({ id: "custom", style: props.mapboxStyle });
@@ -75,11 +78,16 @@ const emitBasemapChange = () => {
     <div
       class="basemap-toggle rounded shadow"
       :class="{ active: showBasemapWindow }"
+      :style="{ top: topPosition }"
       @click="toggleBasemapWindow"
     >
       <img src="/map.svg" alt="Map Icon" />
     </div>
-    <div v-if="showBasemapWindow" class="basemap-window rounded shadow">
+    <div
+      v-if="showBasemapWindow"
+      class="basemap-window rounded shadow"
+      :style="{ top: topPosition }"
+    >
       <div class="basemap-window-content">
         <h3 class="font-semibold mb-2">{{ $t("selectBasemap") }}</h3>
         <label>
@@ -148,7 +156,6 @@ const emitBasemapChange = () => {
 <style scoped>
 .basemap-toggle {
   position: absolute;
-  top: 147px;
   right: 10px;
   padding: 3px;
   width: 30px;
@@ -172,7 +179,6 @@ const emitBasemapChange = () => {
 .basemap-window {
   position: absolute;
   right: 50px;
-  top: 147px;
   background-color: #fff;
   border: 1px solid #ccc;
   z-index: 1001;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "gc-shared-resources": "latest",
         "lodash": "^4.17.21",
         "mapbox-gl": "^3.4.0",
+        "mapbox-gl-ruler-control": "^0.0.2",
         "nuxt": "^3.13.0",
         "nuxt-auth-utils": "^0.3.6",
         "pg": "^8.12.0",
@@ -9255,6 +9256,11 @@
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A=="
     },
+    "node_modules/geolib": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.4.tgz",
+      "integrity": "sha512-EicrlLLL3S42gE9/wde+11uiaYAaeSVDwCUIv2uMIoRBfNJCn8EsSI+6nS3r4TCKDO6+RQNM9ayLq2at+oZQWQ=="
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -11352,6 +11358,14 @@
         "supercluster": "^8.0.1",
         "tinyqueue": "^3.0.0",
         "vt-pbf": "^3.1.3"
+      }
+    },
+    "node_modules/mapbox-gl-ruler-control": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/mapbox-gl-ruler-control/-/mapbox-gl-ruler-control-0.0.2.tgz",
+      "integrity": "sha512-MmHz0efFXAFQ0/vLikdZF8+x8urnhlaQ8R/fv3DLhdnIwtq37yo3L2s4qcdVQY+ai1Me4hD550CSg3LR1CRfrA==",
+      "dependencies": {
+        "geolib": "^3.3.1"
       }
     },
     "node_modules/mapbox-gl/node_modules/earcut": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gc-shared-resources": "latest",
     "lodash": "^4.17.21",
     "mapbox-gl": "^3.4.0",
+    "mapbox-gl-ruler-control": "^0.0.2",
     "nuxt": "^3.13.0",
     "nuxt-auth-utils": "^0.3.6",
     "pg": "^8.12.0",


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/guardianconnector-explorer/issues/84 by adding [`mapbox-gl-ruler-control`](https://github.com/ardhi/mapbox-gl-ruler-control) to the AlertsDashboard component.

## Screenshots

![image](https://github.com/user-attachments/assets/df19181b-717c-4550-af70-06b295080d3b)

## What I changed

* Installed `mapbox-gl-ruler-control` library.
* Implemented the control on `AlertsDashboard` with a few custom style rules to make it look similar to our other map controls.
* Introduced a reactive var `hasRulerControl` (Boolean) to ensure our custom basemap picker control shows up underneath the ruler, if used.

## What I'm not doing here

Writing custom Mapbox code to handle all of this [ala Mapbox's example](https://docs.mapbox.com/mapbox-gl-js/example/measure/). The new library introduced here is pretty lightweight, and while it hasn't been updated in 2 years or doesn't have many repository stars, [the code](https://github.com/ardhi/mapbox-gl-ruler-control/blob/main/src/ruler.js) looks  non-controversial and unlikely to break.