### PR TITLE
On map views, increase point radius and stroke-width

### DIFF
--- a/components/AlertsDashboard.vue
+++ b/components/AlertsDashboard.vue
@@ -416,7 +416,7 @@ const addMapeoData = () => {
       source: "mapeo-data",
       filter: ["==", "$type", "Point"],
       paint: {
-        "circle-radius": 5,
+        "circle-radius": 6,
         "circle-color": [
           // Use filter-color for fallback if selected is false
           "case",

--- a/components/MapView.vue
+++ b/components/MapView.vue
@@ -144,9 +144,9 @@ const addDataToMap = () => {
       source: "data-source",
       filter: ["==", "$type", "Point"],
       paint: {
-        "circle-radius": 6,
+        "circle-radius": 8,
         "circle-color": ["get", "filter-color", ["get", "feature"]],
-        "circle-stroke-width": 2,
+        "circle-stroke-width": 3,
         "circle-stroke-color": "#fff",
       },
     });


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/guardianconnector-explorer/issues/85. I found that simply increasing the `circle-radius` and `circle-stroke-width` made a substantial difference. I opted to not increase the radius as much on `AlertsDashboard` because doing so causes the Mapeo points to obscure the alerts, which are just as important in the visual hierarchy of that view.

## Screenshots

Map:
![image](https://github.com/user-attachments/assets/d35acd47-df7f-4cf4-8597-b5bcd3b6a281)

Alerts:
![image](https://github.com/user-attachments/assets/2d536c9f-1062-4d5d-bb11-716d16ad4db6)


## What I changed

Bumped up `circle-radius` and `circle-stroke-width`